### PR TITLE
CI policy: dependency-change gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -318,3 +318,42 @@ jobs:
           path: |
             artifacts/security/*.json
           retention-days: 30
+
+  deps_policy:
+    name: deps policy
+    # Berlaku untuk PR & push ke main
+    if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Gate PR: butuh label deps/dependencies/renovate/security jika menyentuh lockfile/manifest
+      - name: Gate dependency changes on PR (labels required)
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const {owner, repo} = context.repo;
+            const labels = (await github.rest.issues.listLabelsOnIssue({owner, repo, issue_number: pr.number}))
+              .data.map(l => l.name.toLowerCase());
+            const okLabels = new Set(['deps','dependencies','renovate','security']);
+            const hasAllowed = labels.some(n => okLabels.has(n));
+            const files = await github.paginate(github.rest.pulls.listFiles, {owner, repo, pull_number: pr.number, per_page: 100});
+            const touched = files.map(f => f.filename);
+            const hit = touched.some(f => /(^|\/)(pnpm-lock\.yaml|package\.json)$/.test(f));
+            core.info(`labels: ${labels.join(', ')}`);
+            core.info(`manifest/lockfile changed: ${hit}`);
+            if (hit && !hasAllowed) {
+              core.setFailed('Dependency/lockfile changes detected but PR lacks required label: deps|dependencies|renovate|security');
+            }
+
+      # Larang push langsung ke main yang mengubah lockfile/manifest
+      - name: Forbid dependency changes on direct push to main
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: |
+          PREV=$(git rev-list --max-count=1 "${GITHUB_SHA}^")
+          if git diff --name-only "$PREV" "$GITHUB_SHA" | egrep -E '(^|/)(pnpm-lock\.yaml|package\.json)$'; then
+            echo "Forbidden: changing lockfile/manifest on direct push to main"; exit 1;
+          fi
+          echo "OK: no forbidden dependency changes on push."


### PR DESCRIPTION
Fail PR without deps labels if touching package.json/pnpm-lock.yaml; forbid direct push changes to main.