### PR TITLE
CI: Provenance SBOM only (no attest)

### DIFF
--- a/.github/workflows/provenance.yml
+++ b/.github/workflows/provenance.yml
@@ -56,5 +56,6 @@ jobs:
         with:
           subject-path: artifacts/sbom/*.json
         continue-on-error: true
+      if: false
 
 # if: false


### PR DESCRIPTION
Hilangkan error 254 dari attestation. SBOM tetap dibuat & di-upload.